### PR TITLE
Fix for popup bottom

### DIFF
--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -94,6 +94,10 @@ button, #main .panel-list-item, #open-options {
 	width: calc(100% + 16px) !important;
 }
 
+#footer {
+	overflow: visible;
+}
+
 #open-options {
 	text-align:	center;
 	line-height:	16px;


### PR DESCRIPTION
Hello @ExE-Boss,

When the ```Show privileged pages``` setting is enabled the ```Open Extension Options``` button in the popup is cropped.
Verified in Firefox 58 & 59 on MacOS 10.13.3

| Before | After |
| -- | -- |
| <img width="250" alt="before - final" src="https://user-images.githubusercontent.com/6209647/37571929-e40631b2-2b03-11e8-9957-41d9b2f10245.png"> | <img width="266" alt="after - final" src="https://user-images.githubusercontent.com/6209647/37571928-e36e2174-2b03-11e8-9c21-9380a22f57b1.png"> |

The PR aims to fix that.

